### PR TITLE
Named events zqh

### DIFF
--- a/runtime/common/src/assigned_slots.rs
+++ b/runtime/common/src/assigned_slots.rs
@@ -154,9 +154,9 @@ pub mod pallet {
 	#[pallet::generate_deposit(pub(super) fn deposit_event)]
 	pub enum Event<T: Config> {
 		/// A para was assigned a permanent parachain slot
-		PermanentSlotAssigned(ParaId),
+		PermanentSlotAssigned { para_id: ParaId },
 		/// A para was assigned a temporary parachain slot
-		TemporarySlotAssigned(ParaId),
+		TemporarySlotAssigned { para_id: ParaId },
 	}
 
 	#[pallet::error]
@@ -250,7 +250,7 @@ pub mod pallet {
 			);
 			<PermanentSlotCount<T>>::mutate(|count| count.saturating_inc());
 
-			Self::deposit_event(Event::<T>::PermanentSlotAssigned(id));
+			Self::deposit_event(Event::<T>::PermanentSlotAssigned { para_id: id });
 			Ok(())
 		}
 
@@ -334,7 +334,7 @@ pub mod pallet {
 			TemporarySlots::<T>::insert(id, temp_slot);
 			<TemporarySlotCount<T>>::mutate(|count| count.saturating_inc());
 
-			Self::deposit_event(Event::<T>::TemporarySlotAssigned(id));
+			Self::deposit_event(Event::<T>::TemporarySlotAssigned { para_id: id });
 
 			Ok(())
 		}

--- a/runtime/rococo/src/validator_manager.rs
+++ b/runtime/rococo/src/validator_manager.rs
@@ -47,9 +47,9 @@ pub mod pallet {
 	#[pallet::generate_deposit(pub(super) fn deposit_event)]
 	pub enum Event<T: Config> {
 		/// New validators were added to the set.
-		ValidatorsRegistered(Vec<T::ValidatorId>),
+		ValidatorsRegistered { validators: Vec<T::ValidatorId> },
 		/// Validators were removed from the set.
-		ValidatorsDeregistered(Vec<T::ValidatorId>),
+		ValidatorsDeregistered { validators: Vec<T::ValidatorId> },
 	}
 
 	/// Validators that should be retired, because their Parachain was deregistered.
@@ -75,7 +75,7 @@ pub mod pallet {
 
 			validators.clone().into_iter().for_each(|v| ValidatorsToAdd::<T>::append(v));
 
-			Self::deposit_event(Event::ValidatorsRegistered(validators));
+			Self::deposit_event(Event::ValidatorsRegistered { validators });
 			Ok(())
 		}
 
@@ -91,7 +91,7 @@ pub mod pallet {
 
 			validators.clone().into_iter().for_each(|v| ValidatorsToRetire::<T>::append(v));
 
-			Self::deposit_event(Event::ValidatorsDeregistered(validators));
+			Self::deposit_event(Event::ValidatorsDeregistered { validators });
 			Ok(())
 		}
 	}


### PR DESCRIPTION
- [x] common/src/assigned_slots
- [x] rococo/src/validator_manager

`test-runtime/src/lib` was not included because it requires changes in `xcm/xcm-executor/integration-tests` and based on [this](https://github.com/paritytech/polkadot/pull/5461#issuecomment-1126658572), it might be better to combine it with [this pr](https://github.com/paritytech/polkadot/pull/5564) 
